### PR TITLE
Fix: Falsy values ignored even if valid 

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2524,7 +2524,7 @@ packages:
       mlly: 1.4.2
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@20.5.9)
+      vite: 4.5.2(@types/node@20.5.9)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -2536,8 +2536,8 @@ packages:
       - terser
     dev: true
 
-  /vite@4.4.9(@types/node@20.5.9):
-    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
+  /vite@4.5.2(@types/node@20.5.9):
+    resolution: {integrity: sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -2624,7 +2624,7 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.7.0
-      vite: 4.4.9(@types/node@20.5.9)
+      vite: 4.5.2(@types/node@20.5.9)
       vite-node: 0.34.3(@types/node@20.5.9)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2063,8 +2063,8 @@ packages:
       pathe: 1.1.1
     dev: true
 
-  /postcss@8.4.29:
-    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
+  /postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -2566,7 +2566,7 @@ packages:
     dependencies:
       '@types/node': 20.5.9
       esbuild: 0.18.20
-      postcss: 8.4.29
+      postcss: 8.4.31
       rollup: 3.28.1
     optionalDependencies:
       fsevents: 2.3.3

--- a/validation/package.json
+++ b/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ponch/validation",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A tool to make validations easy!",
   "scripts": {
     "test": "vitest run ./test/",

--- a/validation/src/ArrayValidator.ts
+++ b/validation/src/ArrayValidator.ts
@@ -80,7 +80,7 @@ export class ArrayValidator<
       for (let i = 0; i < subject.length; i++) {
         const result = this.validator.validateSafe(subject[i]);
         if (result.invalid) (<any>invalid)[i] = result.invalid;
-        else if (result.value) value[i] = result.value;
+        else if (result.value !== undefined) value[i] = result.value;
       }
       if (errors.length > 0) invalid._errors = errors;
 

--- a/validation/src/GroupValidator.ts
+++ b/validation/src/GroupValidator.ts
@@ -97,7 +97,7 @@ export class GroupValidator<
       for (const key in this.validators) {
         const result = this.validators[key].validateSafe(subject[key]);
         if (result.invalid) (<any>invalid)[key] = result.invalid;
-        else if (result.value) value[key] = result.value;
+        else if (result.value !== undefined) value[key] = result.value;
       }
       if (errors.length > 0) invalid._errors = errors;
 

--- a/validation/src/TupleValidator.ts
+++ b/validation/src/TupleValidator.ts
@@ -134,7 +134,7 @@ export class TupleValidator<
       for (let i = 0; i < this.validators.length; i++) {
         const result = this.validators[i].validateSafe(subject[i]);
         if (result.invalid) (<any>invalid)[i] = result.invalid;
-        else if (result.value) value[i] = result.value;
+        else if (result.value !== undefined) value[i] = result.value;
       }
       // Run Validator for rest
       if (subject.length > this.validators.length && this.restValidator) {
@@ -142,7 +142,7 @@ export class TupleValidator<
         for (let i = offset; i < subject.length; i++) {
           const result = this.restValidator.validateSafe(subject[i]);
           if (result.invalid) (<any>invalid)[i] = result.invalid;
-          else if (result.value) value[i] = result.value;
+          else if (result.value !== undefined) value[i] = result.value;
         }
       }
       if (errors.length > 0) invalid._errors = errors;

--- a/validation/test/issues/FalsyValues.test.ts
+++ b/validation/test/issues/FalsyValues.test.ts
@@ -1,0 +1,64 @@
+import {describe, expect, test} from 'vitest';
+import {validatorBuilder as builder} from '../../src/helpers/validatorBuilder';
+import {isBoolean, isNumber, isString} from '../../src/helpers/typeFunctions';
+
+// GitHub issue #7 Falsy values in GroupValidator, ArrayValidator and TupleValidator are ignored
+// https://github.com/Ponchoalfonso/validation/issues/7
+describe('Issue: Falsy values ignored when valid', () => {
+  test('Validate correct types and falsy values in a GroupValidator', () => {
+    const falsyGroup = builder.group(true, {
+      str: [isString()],
+      num: [isNumber()],
+      bool: [isBoolean()],
+    });
+    const validated = falsyGroup.validate({str: '', num: 0, bool: false});
+    expect(validated.str).toBe('');
+    expect(validated.num).toBe(0);
+    expect(validated.bool).toBe(false);
+  });
+
+  test('Validate correct types and falsy values in a ArrayValidator', () => {
+    const falsyArrays = builder.group(true, {
+      str: builder.array(false, [isString()]),
+      num: builder.array(false, [isNumber()]),
+      bool: builder.array(false, [isBoolean()]),
+    });
+    const validated = falsyArrays.validate({
+      str: [''],
+      num: [0],
+      bool: [false],
+    });
+    expect(Array.isArray(validated.str)).toBe(true);
+    expect(validated.str?.at(0)).toBe('');
+    expect(Array.isArray(validated.num)).toBe(true);
+    expect(validated.num?.at(0)).toBe(0);
+    expect(Array.isArray(validated.bool)).toBe(true);
+    expect(validated.bool?.at(0)).toBe(false);
+  });
+
+  test('Validate correct types and falsy values in a TupleValidator', () => {
+    const falsyTuples = builder.group(true, {
+      str: builder.tuple(false, [[isString()]]),
+      num: builder.tuple(false, [[isNumber()]]),
+      bool: builder.tuple(false, [[isBoolean()]]),
+      rest: builder.tuple(false, [[isBoolean()]], [isNumber()]),
+    });
+    const validated = falsyTuples.validate({
+      str: [''],
+      num: [0],
+      bool: [false],
+      rest: [false, 0, 0, 0],
+    });
+    expect(Array.isArray(validated.str)).toBe(true);
+    expect(validated.str?.at(0)).toBe('');
+    expect(Array.isArray(validated.num)).toBe(true);
+    expect(validated.num?.at(0)).toBe(0);
+    expect(Array.isArray(validated.bool)).toBe(true);
+    expect(validated.bool?.at(0)).toBe(false);
+    expect(Array.isArray(validated.rest)).toBe(true);
+    expect(validated.rest?.at(0)).toBe(false);
+    expect(validated.rest?.at(1)).toBe(0);
+    expect(validated.rest?.at(2)).toBe(0);
+    expect(validated.rest?.at(3)).toBe(0);
+  });
+});


### PR DESCRIPTION
If falsy values are included in a GroupValidator, ArrayValidator or TupleValidator, resulting object will not include said values even though these are validated correctly both Type and Custom validation wise.